### PR TITLE
+ break navigate into it's own actionGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ Global Flags:
       --expected-texts strings    Pieces of texts that we are looking for in order to confirm a given state on a page is met, which correspond to the check-selectors passed in (in order)
       --headless                 Use headless shell
   -i, --interval int             Interval (in seconds) to wait in between watching a selector (default 30)
-      --wait-error-dump           If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
   -t, --timeout int              Timeout for context - if none is specified a default background context will be used (default -1)
       --urls strings             All URLs to watch
       --wait-error-dump          If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
+      --wait-selectors strings   All selectors, in order of URLs passed in, to wait for
 ```
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Flags:
       --headless        Use headless shell
   -h, --help            help for go-dynamic-fetch
   -t, --timeout int     Timeout for context - if none is specified a default background context will be used (default -1)
+      --wait-error-dump If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
 
 Use "go-dynamic-fetch [command] --help" for more information about a command.
 ```
@@ -44,6 +45,7 @@ Global Flags:
       --config string   config file (default is $HOME/.go-dynamic-fetch.yaml)
       --headless        Use headless shell
   -t, --timeout int     Timeout for context - if none is specified a default background context will be used (default -1)
+      --wait-error-dump If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
 ```
 
 ## Watch
@@ -62,7 +64,6 @@ Flags:
   -h, --help                     help for watch
   -i, --interval int             Interval (in seconds) to wait in between watching a selector (default 30)
       --wait-selectors strings   All selectors, in order of URLs passed in, to wait for
-      --wait-error-dump           If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
       --urls strings             All URLs to watch
 
 Global Flags:
@@ -70,6 +71,7 @@ Global Flags:
       --config string   config file (default is $HOME/.go-dynamic-fetch.yaml)
       --headless        Use headless shell
   -t, --timeout int     Timeout for context - if none is specified a default background context will be used (default -1)
+      --wait-error-dump If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
 ```
 
 ## Email
@@ -93,10 +95,10 @@ Global Flags:
       --expected-texts strings    Pieces of texts that we are looking for in order to confirm a given state on a page is met, which correspond to the check-selectors passed in (in order)
       --headless                 Use headless shell
   -i, --interval int             Interval (in seconds) to wait in between watching a selector (default 30)
-      --wait-selectors strings   All selectors, in order of URLs passed in, to wait for
       --wait-error-dump           If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
   -t, --timeout int              Timeout for context - if none is specified a default background context will be used (default -1)
       --urls strings             All URLs to watch
+      --wait-error-dump          If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log
 ```
 
 # Examples

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/vishnraj/go-dynamic-fetch/fetcher"
@@ -40,8 +39,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		fetcher.Log().Panicf("%v", err)
 	}
 }
 
@@ -56,6 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("headless", false, "Use headless shell")
 	rootCmd.PersistentFlags().StringP("agent", "a", fetcher.DefaultUserAgent, "User agent to request as - if not specified the default is used")
 	rootCmd.PersistentFlags().IntP("timeout", "t", -1, "Timeout for context - if none is specified a default background context will be used")
+	rootCmd.PersistentFlags().Bool("wait-error-dump", false, "If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -67,8 +66,7 @@ func initConfig() {
 		// Find working directory.
 		home, err := os.Getwd()
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			fetcher.Log().Panicf("%v", err)
 		}
 
 		// Search config in home directory with name ".go-dynamic-fetch" (without extension).
@@ -80,6 +78,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		fetcher.Log().Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -42,7 +42,6 @@ func init() {
 
 	watchCmd.PersistentFlags().StringSlice("urls", nil, "All URLs to watch")
 	watchCmd.PersistentFlags().StringSlice("wait-selectors", nil, "All selectors, in order of URLs passed in, to wait for")
-	watchCmd.PersistentFlags().Bool("wait-error-dump", false, "If an error is encountered during the wait phase, where the expected element is not loaded, dump the page contents to the log")
 
 	watchCmd.PersistentFlags().StringSlice("check-selectors", nil, "Selectors that are used to check for the given expected-texts")
 	watchCmd.PersistentFlags().StringSlice("expected-texts", nil, "Pieces of texts that we are looking for in order to confirm a given state on a page is met, which correspond to the check-selectors passed in (in order)")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/apsdehal/go-logger v0.0.0-20190515212710-b0d6ccfee0e6
-	github.com/chromedp/cdproto v0.0.0-20201009231348-1c6a710e77de
+	github.com/chromedp/cdproto v0.0.0-20201009231348-1c6a710e77de // indirect
 	github.com/chromedp/chromedp v0.5.3
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1


### PR DESCRIPTION
+ don't use cdproto tools for now, they seem to block chromedp functions
+ fix wait-error-dumps
+ make wait-error-dumps available for all commands
+ switch all []chromedp.Actions -> chromedp.Tasks